### PR TITLE
ipympl 0.8.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,6 @@ source:
 
 build:
   number: 0
-  # It's currently not supported on s390x
-  skip: True  # [s390x]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,9 @@ source:
 
 build:
   number: 0
+  # It's currently not supported on s390x. 
+  # Yarn is unsatisfiable dependency on s390x
+  skip: True  # [s390x]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -23,6 +26,8 @@ requirements:
     - pip
     - setuptools >=40.8.0
     - wheel
+    # Needed for setup process
+    - yarn
   run:
     - python
     - ipython <9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,44 +1,59 @@
-{% set version = "0.7.0" %}
-{% set sha256 = "f0f1f356d8cb9d4fb51bb86dbbf837c190145316cb72f66081872ebc4d6db0a1" %}
+{% set version = "0.8.6" %}
+{% set sha256 = "d0f4f613aaa4134be0be1e4eefa99182b063701ee47f9b91a6efe19bdc4119c5" %}
 
 package:
-    name: ipympl
-    version: {{ version }}
+  name: ipympl
+  version: {{ version }}
 
 source:
-    fn: ipympl-{{ version }}.tar.gz
-    url: https://pypi.io/packages/source/i/ipympl/ipympl-{{ version }}.tar.gz
-    sha256: {{ sha256 }}
+  fn: ipympl-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/i/ipympl/ipympl-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
-    number: 0
-    noarch: python
-    script: python -m pip install --no-deps --ignore-installed .
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
-    build:
-        - python
-        - setuptools
-        - jupyter
-        - pip
-        - jupyter-packaging
-    run:
-        - python
-        - ipywidgets >=7.5.0,<8.0
-        - ipykernel >=4.7
-        - matplotlib >=2.2.0
-        - six
+  host:
+    - python
+    - jupyter-packaging =0.7
+    - jupyterlab =3
+    - pip
+    - setuptools >=40.8.0
+    - wheel
+    - yarn
+  run:
+    - python
+    - ipython <9
+    - numpy
+    - ipython_genutils
+    - pillow
+    - traitlets <6
+    - ipywidgets >=7.6.0,<8.0
+    - matplotlib-base >=2.0.0,<4
 
 test:
-    imports:
-        - ipympl
+  imports:
+    - ipympl
+  requires:
+    - pip
+  commands:
+    - pip check
+    - test -f ${PREFIX}/share/jupyter/nbextensions/jupyter-matplotlib/extension.js                     # [unix]
+    - test -f ${PREFIX}/share/jupyter/nbextensions/jupyter-matplotlib/index.js                         # [unix]
+    - test -f ${PREFIX}/share/jupyter/labextensions/jupyter-matplotlib/package.json                    # [unix]
+    - if not exist %PREFIX%\\share\\jupyter\\nbextensions\\jupyter-matplotlib\\extension.js (exit 1)   # [win]
+    - if not exist %PREFIX%\\share\\jupyter\\nbextensions\\jupyter-matplotlib\\index.js (exit 1)       # [win]
+    - if not exist %PREFIX%\\share\\jupyter\\labextensions\\jupyter-matplotlib\\package.json (exit 1)  # [win]
 
 about:
-    home: https://github.com/matplotlib/jupyter-matplotlib
-    license: BSD 3-Clause
-    license_family: BSD
-    license_file: LICENSE
-    summary: Matplotlib Jupyter Extension
+  home: https://github.com/matplotlib/ipympl
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: Matplotlib Jupyter Extension
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,6 +58,8 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Matplotlib Jupyter Extension
+  dev_url: https://github.com/matplotlib/ipympl
+  doc_url: https://github.com/matplotlib/ipympl/blob/master/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 
 build:
   number: 0
+  # It's currently not supported on s390x
+  skip: True  # [s390x]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
@@ -23,7 +25,6 @@ requirements:
     - pip
     - setuptools >=40.8.0
     - wheel
-    - yarn
   run:
     - python
     - ipython <9


### PR DESCRIPTION
License: https://github.com/matplotlib/ipympl/blob/0.8.6/LICENSE
Upstream setup file: https://github.com/matplotlib/ipympl/blob/0.8.6/setup.py
Upstream pyproject.toml: https://github.com/matplotlib/ipympl/blob/0.8.6/pyproject.toml
Dev requirements: https://github.com/matplotlib/ipympl/blob/0.8.6/dev-environment.yml (yarn)

Actions:
1. Add `skip: True  # [s390x]`. It's currently not supported on s390x.  and `yarn` is unsatisfiable dependency on s390x
2. Update dependencies
3. Add `pip check`
4. Add tests
5. Fix license name